### PR TITLE
fix corrupted table format

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ We additionally evaluate both methods within the paradigms of "out of the box" a
 ## Meta-Dataset Results
 
 | Dataset                         | Simple CNAPS | Simple CNAPS | Transductive CNAPS | Transductive CNAPS |
+| ---                             | ---          | ---          | ---                | ---                |
 | ```--shuffle_dataset False```   | False        | True         | False              | True               |
 | ---                             | ---          | ---          | ---                | ---                |
 | In-Domain Datasets              | ---          | ---          | ---                | ---                |


### PR DESCRIPTION
# TLDR

- quickly fixed corrupted table format

Since github markdown doesn't support col/row spans, I left other irregular format as it is (e.g. cells with `---`).